### PR TITLE
Fix tild encoding issue in path

### DIFF
--- a/lib/vault/encode.rb
+++ b/lib/vault/encode.rb
@@ -8,13 +8,16 @@ module Vault
     # used as opposed to CGI.escape because in a URL path, space
     # needs to be escaped as %20 and CGI.escapes a space as +.
     #
+    # take the implementation of ERB::Util.url_encode and modified it to exclude slash.
+    # source: https://apidock.com/ruby/v2_6_3/ERB/Util/url_encode
+    #
     # @param [String]
     #
     # @return [String]
     def encode_path(path)
-      path.b.gsub(%r!([^a-zA-Z0-9_.\-/]+)!) { |m|
-        '%' + m.unpack('H2' * m.bytesize).join('%').upcase
-      }
+      path.to_s.b.gsub(/[^a-zA-Z0-9_\-.~\/]/) do |m|
+        sprintf("%%%02X", m.unpack1("C"))
+      end
     end
 
     module_function :encode_path

--- a/spec/integration/api/kv_spec.rb
+++ b/spec/integration/api/kv_spec.rb
@@ -46,8 +46,8 @@ module Vault
       end
 
       it "allows special characters" do
-        subject.write("b:@c%n-read", foo: "bar")
-        secret = subject.read("b:@c%n-read")
+        subject.write("b:@c%.~ n-read", foo: "bar")
+        secret = subject.read("b:@c%.~ n-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
@@ -60,8 +60,8 @@ module Vault
       end
 
       it "returns the secret metadata" do
-        subject.write("b:@c%n-read", foo: "bar")
-        secret = subject.read("b:@c%n-read")
+        subject.write("b:@c%.~ n-read", foo: "bar")
+        secret = subject.read("b:@c%.~ n-read")
         expect(secret).to be
         expect(secret.metadata.keys).to match_array([:created_time, :custom_metadata, :deletion_time, :version, :destroyed])
       end
@@ -95,9 +95,9 @@ module Vault
       end
 
       it "allows special characters" do
-        subject.write("b:@c%n-write", foo: "bar")
-        subject.write("b:@c%n-write", bacon: true)
-        secret = subject.read("b:@c%n-write")
+        subject.write("b:@c%.~ n-write", foo: "bar")
+        subject.write("b:@c%.~ n-write", bacon: true)
+        secret = subject.read("b:@c%.~ n-write")
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
@@ -140,9 +140,9 @@ module Vault
       end
 
       it "allows special characters" do
-        subject.write("b:@c%n-delete", foo: "bar")
-        expect(subject.delete("b:@c%n-delete")).to be(true)
-        expect(subject.read("b:@c%n-delete")).to be(nil)
+        subject.write("b:@c%.~ n-delete", foo: "bar")
+        expect(subject.delete("b:@c%.~ n-delete")).to be(true)
+        expect(subject.read("b:@c%.~ n-delete")).to be(nil)
       end
 
       it "does not error if the secret does not exist" do

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -53,8 +53,8 @@ module Vault
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-read", foo: "bar")
-        secret = subject.read("secret/b:@c%n-read")
+        subject.write("secret/b:@c%.~ n-read", foo: "bar")
+        secret = subject.read("secret/b:@c%.~ n-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
@@ -67,8 +67,8 @@ module Vault
       end
 
       it "allows double slash and special characters" do
-        subject.write("secret/b:@c%n-read-slash", foo: "bar")
-        secret = subject.read("secret///b:@c%n-read-slash")
+        subject.write("secret/b:@c%.~ n-read-slash", foo: "bar")
+        secret = subject.read("secret///b:@c%.~ n-read-slash")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
@@ -91,9 +91,9 @@ module Vault
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-write", foo: "bar")
-        subject.write("secret/b:@c%n-write", bacon: true)
-        secret = subject.read("secret/b:@c%n-write")
+        subject.write("secret/b:@c%.~ n-write", foo: "bar")
+        subject.write("secret/b:@c%.~ n-write", bacon: true)
+        secret = subject.read("secret/b:@c%.~ n-write")
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
@@ -106,9 +106,9 @@ module Vault
       end
 
       it "allows double slash and special characters" do
-        subject.write("secret///b:@c%n-write", foo: "bar")
-        subject.write("secret///b:@c%n-write", bacon: true)
-        secret = subject.read("secret/b:@c%n-write")
+        subject.write("secret///b:@c%.~ n-write", foo: "bar")
+        subject.write("secret///b:@c%.~ n-write", bacon: true)
+        secret = subject.read("secret/b:@c%.~ n-write")
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
@@ -131,9 +131,9 @@ module Vault
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-delete", foo: "bar")
-        expect(subject.delete("secret/b:@c%n-delete")).to be(true)
-        expect(subject.read("secret/b:@c%n-delete")).to be(nil)
+        subject.write("secret/b:@c%.~ n-delete", foo: "bar")
+        expect(subject.delete("secret/b:@c%.~ n-delete")).to be(true)
+        expect(subject.read("secret/b:@c%.~ n-delete")).to be(nil)
       end
 
       it "allows double slash" do
@@ -143,9 +143,9 @@ module Vault
       end
 
       it "allows double slash and special characters" do
-        subject.write("secret/b:@c%n-delete-slash", foo: "bar")
-        expect(subject.delete("secret///b:@c%n-delete-slash")).to be(true)
-        expect(subject.read("secret/b:@c%n-delete-slash")).to be(nil)
+        subject.write("secret/b:@c%.~ n-delete-slash", foo: "bar")
+        expect(subject.delete("secret///b:@c%.~ n-delete-slash")).to be(true)
+        expect(subject.read("secret/b:@c%.~ n-delete-slash")).to be(nil)
       end
 
       it "does not error if the secret does not exist" do


### PR DESCRIPTION
The current code escapes ~ as %7E, but is shouldn't.